### PR TITLE
Insert missing link to Point-in-time recovery

### DIFF
--- a/docs/working-with-binary-logs.md
+++ b/docs/working-with-binary-logs.md
@@ -24,7 +24,7 @@ You can find the binary log position corresponding to a backup after the backup 
 
 To perform a point-in-time recovery from an `xtrabackup` backup, you should prepare and restore the backup, and then replay binary logs from the point shown in the `xtrabackup_binlog_info` file.
 
-A more detailed procedure is found here.
+A more detailed procedure is found [here](point-in-time-recovery.md).
 
 ## Set up a new replication replica
 


### PR DESCRIPTION
The text read _'A more detailed procedure is found here.'_ signalling a probably missing link. The file `point-in-time-recovery.md` contains detailed information on working with binary logs, so we can safely assume it should be linked.