### PR TITLE
Remove 8.0 references in 8.1

### DIFF
--- a/docs/accelerate-backup-process.md
+++ b/docs/accelerate-backup-process.md
@@ -57,7 +57,7 @@ TABLES WITH READ LOCK` and once during to minimize the time the read lock is
 being held. During the second `rsync` call, it will only synchronize the
 changes to non-transactional data (if any) since the first call performed before
 the `FLUSH TABLES WITH READ LOCK`. Note that Percona XtraBackup will use
-[Backup locks](https://docs.percona.com/percona-server/8.0/backup-locks.html)
+[Backup locks](https://docs.percona.com/percona-server/8.1/backup-locks.html)
 where available as a lightweight alternative to `FLUSH TABLES WITH READ
 LOCK`.
 

--- a/docs/binaries-overview.md
+++ b/docs/binaries-overview.md
@@ -6,8 +6,8 @@ Percona XtraBackup contains a set of the following binaries:
 
 * [xbcrypt](xbcrypt-binary-overview.md) - a utility used for encrypting and decrypting backup files.
 
-* [xbstream](xbstream-binary-overview.md) - a utility that allows streaming and extracting files to / from the xbstream format.
+* [xbstream](xbstream-binary-overview.md) - a utility that allows streaming and extracting files to or from the xbstream format.
 
-* [xbcloud](xbcloud-binary-overview.md) - a utility used for downloading and uploading full or part of xbstream archive from / to cloud.
+* [xbcloud](xbcloud-binary-overview.md) - a utility used for downloading and uploading full or part of xbstream archive from or to cloud.
 
 The recommended way to take the backup is by using the xtrabackup script. For more information on script options, see [xtrabackup](xtrabackup-binary-overview.md).

--- a/docs/create-gtid-replica.md
+++ b/docs/create-gtid-replica.md
@@ -75,28 +75,12 @@ $ chown mysql:mysql /path/to/mysql/datadir
 
 Set the `gtid_purged` variable to the `GTID` from
 `xtrabackup_binlog_info`. Then, update the information about the
-source node and, finally, start the replica. Run the following commands on
-the replica if you are using a version before 8.0.22:
+source node and, finally, start the replica.
 
-```{.bash data-prompt="#"}
-# Using the mysql shell
- > SET SESSION wsrep_on = 0;
- > RESET MASTER;
- > SET SESSION wsrep_on = 1;
- > SET GLOBAL gtid_purged='<gtid_string_found_in_xtrabackup_binlog_info>';
- > CHANGE MASTER TO
-             MASTER_HOST="$masterip",
-             MASTER_USER="repl",
-             MASTER_PASSWORD="$slavepass",
-             MASTER_AUTO_POSITION = 1;
- > START SLAVE;
-```
-
-If you are using version 8.0.22 or later, use `START REPLICA` instead
-of `START SLAVE`. `START SLAVE` is deprecated as of that release. If you
-are using version 8.0.21 or earlier, use `START SLAVE`.
-
-If you are using a version 8.0.23 or later, run the following commands:
+!!! note
+   
+    The example above is applicable to Percona XtraDB Cluster.
+    The `wsrep_on` variable is set to 0 before resetting the source (`RESET MASTER`). The reason is that Percona XtraDB Cluster will not allow resetting the source if `wsrep_on=1`.
 
 ```{.bash data-prompt="#"}
 # Using the mysql shell
@@ -111,14 +95,6 @@ If you are using a version 8.0.23 or later, run the following commands:
              SOURCE_AUTO_POSITION = 1;
  > START REPLICA;
 ```
-
-If you are using version 8.0.23 or later,
-use [CHANGE_REPLICATION_SOURCE_TO and the appropriate options](https://dev.mysql.com/doc/refman/8.0/en/change-replication-source-to.html). `CHANGE_MASTER_TO` is deprecated as of that release.
-
-!!! note
-   
-    The example above is applicable to Percona XtraDB Cluster.
-    The `wsrep_on` variable is set to 0 before resetting the source (`RESET MASTER`). The reason is that Percona XtraDB Cluster will not allow resetting the source if `wsrep_on=1`.
 
 ## 5. Check the replication status
 
@@ -139,10 +115,6 @@ The results should be similar to the following:
     Retrieved_Gtid_Set: c777888a-b6df-11e2-a604-080027635ef5:5
     Executed_Gtid_Set: c777888a-b6df-11e2-a604-080027635ef5:1-5
     ```
-
-!!! note
-   
-    The command [SHOW SLAVE STATUS](https://dev.mysql.com/doc/refman/8.0/en/show-slave-status.html) is deprecated. Use [SHOW REPLICA STATUS](https://dev.mysql.com/doc/refman/8.0/en/show-replica-status.html).
 
 We can see that the replica has retrieved a new transaction with number 5,
 so transactions from 1 to 5 are already on this slave.

--- a/docs/dictionary-cache.md
+++ b/docs/dictionary-cache.md
@@ -1,6 +1,6 @@
 # Dictionary cache 
 
-Percona XtraBackup is based on how [`crash recovery`](https://dev.mysql.com/doc/refman/8.0/en/glossary.html#glos_crash_recovery) works. Percona XtraBackup copies the InnoDB data files, which results in data that is internally inconsistent; then the `prepare` phase performs crash recovery on the files to make a consistent, usable database again.
+Percona XtraBackup is based on how [`crash recovery`](https://dev.mysql.com/doc/refman/8.1/en/glossary.html#glos_crash_recovery) works. Percona XtraBackup copies the InnoDB data files, which results in data that is internally inconsistent; then the `prepare` phase performs crash recovery on the files to make a consistent, usable database again.
 
 The `--prepare` phase has the following operations:
 

--- a/docs/encrypted-innodb-tablespace-backups.md
+++ b/docs/encrypted-innodb-tablespace-backups.md
@@ -1,6 +1,8 @@
+<!--- We should probably remove the info about `keyring_file` plugin-->
+
 # Encrypted InnoDB tablespace backups
 
-InnoDB supports [data encryption for InnoDB tables](https://dev.mysql.com/doc/refman/8.0/en/innodb-data-encryption.html)
+InnoDB supports [data encryption for InnoDB tables](https://dev.mysql.com/doc/refman/8.1/en/innodb-data-encryption.html)
 stored in file-per-table tablespaces. This feature provides an at-rest
 encryption for physical tablespace data files.
 
@@ -10,26 +12,13 @@ the tablespace key. The master encryption key is stored in a keyring.
 xtrabackup supports two keyring plugins: `keyring_file`, and 
 `keyring_vault`. These plugins are installed into the `plugin` directory.
 
-<!---
-## Version updates
-
-Percona XtraBackup 8.0.25-17 adds support for the `keyring_file` component,
-which is part of the component-based infrastructure MySQL which extends the
-server capabilities. The component is stored in the `plugin` directory.
-
-See a [comparison of keyring components and keyring plugins](https://dev.mysql.com/doc/refman/8.0/en/keyring-component-plugin-comparison.html)
-for more information.
-
-Percona XtraBackup 8.0.27-19 adds support for the Key Management
-Interoperability Protocol (KMIP) which enables the communication between
-the key management system and encrypted database server. 
-
-Percona XtraBackup 8.0.28-21 adds support for the Amazon Key Management
+Percona XtraBackup supports the Amazon Key Management
 Service (AWS KMS). AWS KMS is cloud-based encryption and key management
 service. The keys and functionality can be used for other AWS services
 or your applications that use AWS. No configuration is required to back
 up a server with AWS KMS-enabled encryption. 
---->
+
+<!--- We should probably remove the info about `keyring_file` plugin
 ## Use `keyring_file` plugin
 
 In order to back up and prepare a database containing encrypted InnoDB  
@@ -80,8 +69,7 @@ keyring used when the backup was taken and prepared.
 
 ## Use `keyring_vault` plugin
 
-Keyring vault plugin settings are
-described [here](https://www.percona.com/doc/percona-server/LATEST/security/using-keyring-plugin.html#using-keyring-plugin).
+Keyring vault plugin settings are described in [Use the keyring component or keyring plugin](https://docs.percona.com/percona-server/8.1/using-keyring-plugin.html).
 
 ### Create a backup with the `keyring_vault` plugin
 
@@ -113,7 +101,7 @@ $ xtrabackup --prepare --target-dir=/data/backup \
 --keyring-vault-config=/etc/vault.cnf
 ```
 
-Review [using the keyring vault plugin](https://www.percona.com/doc/percona-server/LATEST/security/using-keyring-plugin.html#using-keyring-plugin) for a description of keyring vault plugin settings.
+Review [Use the keyring component or keyring plugin](https://docs.percona.com/percona-server/8.1/using-keyring-plugin.html) for a description of keyring vault plugin settings.
 
 After xtrabackup completes the action, the following message confirms
 the action:
@@ -131,13 +119,14 @@ option:
 ```{.bash data-prompt="$"}
 $ xtrabackup --copy-back --target-dir=/data/backup --datadir=/data/mysql
 ```
+-->
 
 ## Use the `keyring_file` component
 
 A component is not loaded with the `--early_plugin_load` option. The 
 server uses a manifest to load the component and the component has its 
 own configuration file. See the [MySQL documentation on the component 
-installation](https://dev.mysql.com/doc/refman/8.0/en/keyring-component-installation.html) for more 
+installation](https://dev.mysql.com/doc/refman/8.1/en/keyring-component-installation.html) for more 
 information.
 
 An example of a manifest and a configuration file follows:
@@ -159,11 +148,11 @@ An example of `/lib/plugin/component_keyring_file.cnf`:
 ```
 
 For more information,
-see [Keyring Component Installation](https://dev.mysql.com/doc/refman/8.0/en/keyring-component-installation.html)
-and [Using the keyring_file File-Based Keyring Plugin](https://dev.mysql.com/doc/refman/8.0/en/keyring-file-plugin.html).
+see [Keyring Component Installation](https://dev.mysql.com/doc/refman/8.1/en/keyring-component-installation.html)
+and [Using the keyring_file File-Based Keyring Plugin](https://dev.mysql.com/doc/refman/8.1/en/keyring-file-plugin.html).
 
 With the appropriate privilege, you can `SELECT` on
-the [performance_schema.keyring_component_status table](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-keyring-component-status-table.html)
+the [performance_schema.keyring_component_status table](https://dev.mysql.com/doc/refman/8.1/en/performance-schema-keyring-component-status-table.html)
 to view the attributes and status of the installed keyring component 
 when in use.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,7 +63,7 @@ Percona XtraBackup will not be able to take a consistent backup. Retry the backu
  --->
 !!! note
    
-    *   Redo logging is disabled during a [sorted index build](https://dev.mysql.com/doc/refman/8.0/en/sorted-index-builds.html). To avoid this error, Percona XtraBackup can use metadata locks on tables while they are copied:
+    *   Redo logging is disabled during a [sorted index build](https://dev.mysql.com/doc/refman/8.1/en/sorted-index-builds.html). To avoid this error, Percona XtraBackup can use metadata locks on tables while they are copied:
 
     * To block all DDL operations, use the `--lock-ddl` option that issues `LOCK TABLES FOR BACKUP`.
 

--- a/docs/flush-tables-with-read-lock.md
+++ b/docs/flush-tables-with-read-lock.md
@@ -22,9 +22,9 @@ Long-running queries with `FLUSH TABLES WITH READ LOCK` enabled can leave the se
 
 !!! note
    
-    All operations described in this section have no effect when [backup locks](https://docs.percona.com/percona-server/8.0/backup-locks.html) are used.
+    All operations described in this section have no effect when [backup locks](https://docs.percona.com/percona-server/8.1/backup-locks.html) are used.
 
-    Percona XtraBackup uses [Backup locks](https://docs.percona.com/percona-server/8.0/backup-locks.html)
+    Percona XtraBackup uses [Backup locks](https://docs.percona.com/percona-server/8.1/backup-locks.html)
     where available as a lightweight alternative to `FLUSH TABLES WITH READ
     LOCK`. This operation automatically copies non-InnoDB data and avoids blocking DML queries that modify InnoDB tables.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -124,7 +124,7 @@ Specifies the names, sizes and location of shared tablespace files:
 
 ## innodb\_file\_per\_table
 
-By default, InnoDB creates tables and indexes in a [file-per-tablespace](https://dev.mysql.com/doc/refman/8.0/en/innodb-file-per-table-tablespaces.html). If the `innodb_file_per_table` variable is disabled, you can enable the variable in your configuration file:
+By default, InnoDB creates tables and indexes in a [file-per-tablespace](https://dev.mysql.com/doc/refman/8.1/en/innodb-file-per-table-tablespaces.html). If the `innodb_file_per_table` variable is disabled, you can enable the variable in your configuration file:
 
 > \[mysqld\]<br/>
 > innodb\_file\_per\_table <br/>
@@ -186,7 +186,7 @@ To support simultaneous compression and streaming, Percona XtraBackup uses the x
 
 ## XtraDB
 
-Percona XtraDB is an enhanced version of the InnoDB storage engine, designed to better scale on modern hardware. Percona XtraDB includes features which are useful in a high performance environment. It is fully backward-compatible, and is a drop-in replacement for the standard InnoDB storage engine. For more information, see [The Percona XtraDB Storage Engine](https://www.percona.com/doc/percona-server/8.0/percona_xtradb.html).
+Percona XtraDB is an enhanced version of the InnoDB storage engine, designed to better scale on modern hardware. Percona XtraDB includes features which are useful in a high performance environment. It is fully backward-compatible, and is a drop-in replacement for the standard InnoDB storage engine. For more information, see [The Percona XtraDB Storage Engine](https://www.percona.com/doc/percona-server/8.1/percona-xtradb.html).
 
 ## Zstandard (ZSTD)
 

--- a/docs/how-xtrabackup-works.md
+++ b/docs/how-xtrabackup-works.md
@@ -18,7 +18,7 @@ Percona XtraBackup remembers the LSN when it starts, and then copies the data fi
 at different points in time. Percona XtraBackup also runs a
 background process that watches the transaction log files, and copies any changes. Percona XtraBackup does this continually. The transaction logs are written in a round-robin fashion, and can be reused.
 
-Percona XtraBackup uses [Backup locks](https://docs.percona.com/percona-server/8.0/backup-locks.html)
+Percona XtraBackup uses [Backup locks](https://docs.percona.com/percona-server/8.1/backup-locks.html)
 
 where available as a lightweight alternative to `FLUSH TABLES WITH READ
 LOCK`. MySQL {{release}} allows
@@ -46,7 +46,7 @@ needed even with the `--slave-info` option.
 
 !!! admonition "See also"
 
-    [MySQL Documentation: LOCK INSTANCE FOR BACKUP](https://dev.mysql.com/doc/refman/8.0/en/lock-instance-for-backup.html)
+    [MySQL Documentation: LOCK INSTANCE FOR BACKUP](https://dev.mysql.com/doc/refman/8.1/en/lock-instance-for-backup.html)
 
 When backup locks are supported by the server, xtrabackup first copies
 InnoDB data, runs the `LOCK TABLES FOR BACKUP` and then copies the MyISAM

--- a/docs/lock-options.md
+++ b/docs/lock-options.md
@@ -36,7 +36,7 @@ These assumptions may not be correct and may lead to inconsistent backups.
 
 ## `--lock-ddl-per-table` redesign
 
-Implemented in Percona XtraBackup version 8.0.22-15.0, the `--lock-ddl-per-table` has been redesigned to minimize inconsistent backups.
+The `--lock-ddl-per-table` option has been redesigned to minimize inconsistent backups.
 
 The following procedure reorders the steps:
 

--- a/docs/privileges.md
+++ b/docs/privileges.md
@@ -68,7 +68,7 @@ The database user needs the following privileges to back up tables or databases:
 * `RELOAD` and `LOCK TABLES` (unless the `--no-lock`
 option is specified) in order to run `FLUSH TABLES WITH READ LOCK` and
 `FLUSH ENGINE LOGS` prior to start copying the files, and requires this
-privilege when [Backup Locks](https://docs.percona.com/percona-server/8.0/backup-locks.html)
+privilege when [Backup Locks](https://docs.percona.com/percona-server/8.1/backup-locks.html)
 are used
 
 * `BACKUP_ADMIN` privilege is needed to query the
@@ -84,8 +84,7 @@ mandatory), and optionally to see all threads which are running on the
 server (see FLUSH TABLES WITH READ LOCK option),
 
 * `SUPER` in order to start/stop the replication threads in a replication
-environment, use [XtraDB Changed Page Tracking](https://www.percona.com/doc/percona-server/8.0/changed_page_tracking.html)
-for Incremental Backups and for handling FLUSH TABLES WITH READ LOCK,
+environment,
 
 * `CREATE` privilege in order to create the
 PERCONA_SCHEMA.xtrabackup_history database and

--- a/docs/quickstart-overview.md
+++ b/docs/quickstart-overview.md
@@ -20,13 +20,17 @@ You can install Percona XtraBackup using different methods:
 
 Percona Server for MySQL (PS) is a freely available, fully compatible, enhanced, and open source drop-in replacement for any MySQL database. It provides superior and optimized performance, greater scalability and availability, enhanced backups, increased visibility, and instrumentation. Percona Server for MySQL is trusted by thousands of enterprises to provide better performance and concurrency for their most demanding workloads.
 
-Install [Percona Server for MySQL](https://docs.percona.com/percona-xtradb-cluster/8.0/install/index.html).
+Install [Percona Server for MySQL](https://docs.percona.com/percona-server/8.1/installation.html).
+
+<!--- Do we need PXC? We do not have PXC 8.1 branch
 
 ## For high availability
 
 Percona XtraDB Cluster (PXC) is a 100% open source, enterprise-grade, highly available clustering solution for MySQL multi-master setups based on Galera. PXC helps enterprises minimize unexpected downtime and data loss, reduce costs, and improve performance and scalability of your database environments supporting your critical business applications in the most demanding public, private, and hybrid cloud environments. 
 
 Install [Percona XtraDB Cluster](https://docs.percona.com/percona-xtradb-cluster/8.0/install/index.html).
+
+ -->
 
 ## For Monitoring and Management
 

--- a/docs/restore-individual-partitions.md
+++ b/docs/restore-individual-partitions.md
@@ -20,7 +20,7 @@ PRIMARY KEY (`id`)
 
 !!! note
    
-    Generate a [.cfg metadata file](https://dev.mysql.com/doc/refman/8.0/en/innodb-table-import.html) by running `FLUSH TABLES ... FOR EXPORT`. The command can only be run on a table, not on the individual table partitions.
+    Generate a [.cfg metadata file](https://dev.mysql.com/doc/refman/8.1/en/innodb-table-import.html) by running `FLUSH TABLES ... FOR EXPORT`. The command can only be run on a table, not on the individual table partitions.
     The file is located in the table schema directory and is used for schema verification when importing the tablespace. 
 
 To restore the partition from the backup, the tablespace must be discarded for

--- a/docs/set-up-replication.md
+++ b/docs/set-up-replication.md
@@ -10,17 +10,16 @@ task. Percona XtraBackup is designed to solve this problem.
 You can have almost real-time backups in 6 simple steps by setting up a
 replication environment with Percona XtraBackup.
 
-## All the things you will need
+## Things you need
 
 Setting up a replica for replication with *Percona XtraBackup* is a
 straightforward procedure. In order to keep it simple, here is a list of
-the
-things you need to follow the steps without hassles:
+the things you need to follow the steps without hassles:
 
 `Source`
 
 A system with a *MySQL*-based server installed, configured and running. This
-system will be called `Source`, as it is where your data is stored and the one to be replicated. We will assume the following about this system:
+system is called `Source`. The `Source` server stores your data and can be replicated. We assume the following about this system:
 
 * the *MySQL* server is able to communicate with others by the standard TCP/IP port;
 
@@ -38,30 +37,20 @@ system will be called `Source`, as it is where your data is stored and the one t
 
 `Replica`
 
-Another system, with a *MySQL*-based server installed on it. We
-will refer to this machine as `Replica` and we will assume the same things
+Another system, with a *MySQL*-based server installed on it. We refer to this machine as `Replica` and assume the same things
 we did about `Source`, except that the server-id on `Replica` is 2.
 
 `Percona XtraBackup`
 
-The backup tool we will use. It should be installed in both computers for convenience.
+We use this backup tool. Install Percona XtraBackup on both computers for convenience.
 
 !!! note
    
     It is not recommended to mix MySQL variants (Percona Server, MySQL) in your replication setup. This may produce incorrect `xtrabackup_slave_info` file when adding a new replica. 
 
-## Version updates
-
-The 8.0.23 version deprecates the `CHANGE_MASTER_TO` command. In that 
-version and later, use
-the [CHANGE_REPLICATION_SOURCE_TO and the appropriate options](https://dev.mysql.com/doc/refman/8.0/en/change-replication-source-to.html) instead.
-
-The 8.0.22 version deprecates the`START SLAVE` command. In that version or 
-later, use `START REPLICA` instead.
-
 ## 1. Make a backup on the `Source` and prepare it
 
-At the  `Source`, issue the following to a shell:
+At the `Source`, issue the following to a shell:
 
 ```{.bash data-prompt="$"}
 $ xtrabackup --backup --user=yourDBuser --password=MaGiCdB1 --target-dir=/path/to/backupdir
@@ -75,27 +64,24 @@ After this is finished you should get:
     xtrabackup: completed OK!
     ```
 
-This will make a copy of your *MySQL* data dir
+This operation makes a copy of your *MySQL* data dir
 to the `/path/to/backupdir` directory.
 You have told *Percona XtraBackup* to connect to the database server
 using your database user and password,
 and do a hot backup of all your data in it
 (all *MyISAM*, *InnoDB* tables and indexes in them).
 
-In order for snapshot to be consistent you need to prepare the data on the
+In order for snapshot to be consistent, prepare the data on the
 source:
 
 ```{.bash data-prompt="$"}
 $ xtrabackup --prepare --target-dir=/path/to/backupdir
 ```
 
-You need to select path where your snapshot has been taken.
-If everything is ok you should get the same OK message.
-Now the transaction logs are applied to the data files,
-and new ones are created:
-your data files are ready to be used by the MySQL server.
+Select the path where your snapshot has been taken.
+Apply the transaction logs to the data files and your data files are ready to be used by the MySQL server.
 
-*Percona XtraBackup* knows where your data is by reading your my.cnf file.
+Percona XtraBackup reads the my.cnf file to locate your data.
 If you have your configuration file in a non-standard place,
 you should use the flag `--defaults-file` `=/location/of/my.cnf`.
 
@@ -107,8 +93,7 @@ you can set it up in `.mylogin.cnf` as follows:
 mysql_config_editor set --login-path=client --host=localhost --user=root --password
 ```
 
-For more information, see [MySQL Configuration
-Utility](https://dev.mysql.com/doc/refman/8.0/en/mysql-config-editor.html).
+For more information, see [MySQL Configuration Utility](https://dev.mysql.com/doc/refman/8.1/en/mysql-config-editor.html).
 
 This statement provides root access to MySQL.
 
@@ -122,10 +107,14 @@ we recommend that you stop the `mysqld` there.
 $ rsync -avpP -e ssh /path/to/backupdir Replica:/path/to/mysql/
 ```
 
-After data has been copied, you can back up the original or previously
-installed *MySQL* datadir (**NOTE**: Make sure mysqld is shut down before
-you move the contents of its datadir, or move the snapshot into its
-datadir.). Run the following commands on the Replica:
+After data is copied, you can back up the original or previously
+installed *MySQL* datadir. 
+
+!!! note
+
+    Make sure mysqld is shut down before you move the contents of its datadir, or move the snapshot into its datadir.
+
+Run the following commands on the Replica:
 
 ```{.bash data-prompt="$"}
 $ mv /path/to/mysql/datadir /path/to/mysql/datadir_bak
@@ -196,8 +185,7 @@ and updated in `/etc/mysql/debian.cnf`.
 
 ## 5. Start the replication
 
-On the `Replica`, review the content of the file `xtrabackup_binlog_info`,
-it will be something like:
+On the `Replica`, review the content of the `xtrabackup_binlog_info` file:
 
 ```{.bash data-prompt="$"}
 $ cat /var/lib/mysql/xtrabackup_binlog_info
@@ -211,14 +199,10 @@ The results should resemble the following:
     Source-bin.000001     481
     ```
 
-[The term `master` is deprecated](#version-updates). Do the following on a 
-MySQL console and use the username and
-password you’ve set up in STEP 3 :
+Do the following on a MySQL console and use the username and
+password you’ve set up in STEP 3:
 
-* Version 8.0.23 or later, use the `CHANGE_REPLICATION_SOURCE_TO` statement
-
-* Before 8.0.23, use the `CHANGE MASTER` statement
-
+Use the `CHANGE_REPLICATION_SOURCE_TO` statement
 
 ```sql
 CHANGE REPLICATION SOURCE TO
@@ -234,11 +218,6 @@ Start the replica:
 ```sql
 START REPLICA;
 ```
-
-The [term `slave` is deprecated](#version-updates). Do the following:
-
-* Version 8.0.22 or later, use `START REPLICA`
-* Before version 8.0.22, use `START SLAVE`
 
 ## 6. Check
 
@@ -291,9 +270,11 @@ $ xtrabackup --prepare --use-memory=2G --target-dir=/path/to/backupdir/
 
     In the ``prepare`` phase, the `--use-memory` parameter speeds up the process if the amount of RAM assigned to the option is available. Use the parameter only in the `prepare` phase. In the other phases the parameter makes the application lazy allocate this memory (reserve) but does not affect database pages.
 
-Copy the directory from the `Replica` to the `NewReplica` (**NOTE**: Make
-sure mysqld is shut down on the `NewReplica` before you copy the contents
-the snapshot into its datadir.):
+Copy the directory from the `Replica` to the `NewReplica`:
+
+!!! note:
+
+    Make sure mysqld is shut down on the `NewReplica` before you copy the contents the snapshot into its datadir.
 
 ```
 rsync -avprP -e ssh /path/to/backupdir NewReplica:/path/to/mysql/datadir
@@ -323,30 +304,20 @@ server-id=3
 
 After setting `server_id`, start **mysqld**.
 
-Fetch the master_log_file and master_log_pos from the
+Fetch the source_log_file and source_log_pos from the
 file `xtrabackup_slave_info`, execute the statement for setting up the
 source and the log file for the NewReplica:
 
-```{.bash data-prompt=">"}
-> CHANGE MASTER TO
-     MASTER_HOST='$Sourceip',
-     MASTER_USER='repl',
-     MASTER_PASSWORD='$replicapass',
-     MASTER_LOG_FILE='Source-bin.000001',
-     MASTER_LOG_POS=481;
+```sql
+CHANGE REPLICATION SOURCE TO
+    SOURCE_HOST='$sourceip',
+    SOURCE_USER='repl',
+    SOURCE_PASSWORD='$replicapass',
+    SOURCE_LOG_FILE='Source-bin.000001',
+    SOURCE_LOG_POS=481;
 ```
 
-[The term `master` is deprecated](#version-updates). Do the following 
-and then start the replica:
-
-* Version 8.0.23 or later, use the `CHANGE_REPLICATION_SOURCE_TO` statement
-
-* Before 8.0.23, use the `CHANGE MASTER` statement
-
-[The term `slave` is deprecated](#version-updates). Do the following:
-
-* Version 8.0.22 or later, use `START REPLICA`.
-* Before version 8.0.22, use `START SLAVE`
+Start the replica:
 
 ```{.bash data-prompt=">"}
 > START REPLICA;

--- a/docs/smart-memory-estimation.md
+++ b/docs/smart-memory-estimation.md
@@ -20,9 +20,9 @@ Percona XtraBackup performs the backup procedure in two steps:
 
 ## How does Smart memory estimation work
 
-In the `prepare` phase, Percona XtraBackup checks the server's available free memory and uses that memory up to the limit specified in the [`--use-free-memory-pct`](xtrabackup-option-reference.md#use-free-memory-pct) option to run `--prepare`. Due to backward compatibility, the default value for the `--use-free-memory-pct` option is 0 (zero), which defines the option as disabled. For example, if you set `--use-free-memory-pct=50`, then 50% of the free memory is used to `prepare` a backup.
+To run `prepare`, Percona XtraBackup checks the server's available free memory and uses that memory up to the limit specified in the [`--use-free-memory-pct`](xtrabackup-option-reference.md#use-free-memory-pct) option. Due to backward compatibility, the default value for the `--use-free-memory-pct` option is 0 (zero), which defines the option as disabled. For example, if you set `--use-free-memory-pct=50`, then 50% of the free memory is used to `prepare` a backup.
 
-Starting with Percona XtraBackup 8.0.32-26, you can enable or disable the memory estimation during the `backup` phase with the [`--estimate-memory`](xtrabackup-option-reference.md#estimate-memory) option. The default value is `OFF`. Enable the memory estimation with  `--estimate-memory=ON`:
+You can enable or disable the memory estimation during the `backup` phase with the [`--estimate-memory`](xtrabackup-option-reference.md#estimate-memory) option. The default value is `OFF`. Enable the memory estimation with  `--estimate-memory=ON`:
 
 ```{.bash data-prompt="$"}
 $ xtrabackup --backup --estimate-memory=ON --target-dir=/data/backups/

--- a/docs/varify-backup.md
+++ b/docs/varify-backup.md
@@ -110,4 +110,4 @@ This output shows that source and the replica aren’t in consistent state
 and that the difference is in the `mysql.user` table.
 
 More information on different options that pt-table-checksum provides can
-be found in the *pt-table-checksum* [documentation](http://www.percona.com/doc/percona-toolkit/2.2/pt-table-checksum.html).
+be found in the *pt-table-checksum* [documentation](https://docs.percona.com/percona-toolkit/pt-table-checksum.html).

--- a/docs/work-with-apparmor.md
+++ b/docs/work-with-apparmor.md
@@ -4,7 +4,7 @@ The Linux Security Module implements mandatory access controls (MAC) with AppArm
 
 Percona XtraBackup does not have a profile and is not confined by AppArmor.
 
-For a list of common AppArmor commands, see [Percona Server for MySQL - AppArmor](https://www.percona.com/doc/percona-server/LATEST/security/apparmor.html)
+For a list of common AppArmor commands, see [Percona Server for MySQL - AppArmor](https://www.percona.com/percona-server/8.1/apparmor.html)
 
 ## Develop a profile
 

--- a/docs/work-with-selinux.md
+++ b/docs/work-with-selinux.md
@@ -105,7 +105,7 @@ Create the `xtrabackup.fc` file and add content. This file defines the security 
 
 Download the `xtrabackup.te` file from the following location:
 
-[https://github.com/percona/percona-xtrabackup/tree/8.0/packaging/percona/selinx](https://github.com/percona/percona-xtrabackup/tree/8.0/packaging/percona/selinx)
+[https://github.com/percona/percona-xtrabackup/tree/trunk/packaging/percona/selinx](https://github.com/percona/percona-xtrabackup/tree/trunk/packaging/percona/selinx)
 
 !!! note
  

--- a/docs/working-with-binary-logs.md
+++ b/docs/working-with-binary-logs.md
@@ -15,11 +15,6 @@ You can find the binary log position corresponding to a backup after the backup 
     210715 14:15:00 completed OK!
     ```
 
-!!! note
-   
-    As of Percona XtraBackup 8.0.26-18.0, xtrabackup no longer creates the `xtrabackup_binlog_pos_innodb` file. This change is because MySQL and Percona Server no longer update the binary log information on global transaction system section of `ibdata`. You should rely on `xtrabackup_binlog_info` regardless of the storage engine in use.
-
-
 ## Point-in-time recovery
 
 To perform a point-in-time recovery from an `xtrabackup` backup, you should prepare and restore the backup, and then replay binary logs from the point shown in the `xtrabackup_binlog_info` file.
@@ -28,8 +23,6 @@ Find a more detailed procedure in the [Point-in-time recovery](point-in-time-rec
 
 ## Set up a new replication replica
 
-To set up a new replica, you should prepare the backup, and restore it to the data directory of your new replication replica. If you are using version 8.0.22 or earlier, in your `CHANGE MASTER TO` command, use the binary log filename and position shown in the `xtrabackup_binlog_info` file to start replication.
+To set up a new replica, you should prepare the backup, and restore it to the data directory of your new replication replica. In the [CHANGE_REPLICATION_SOURCE_TO with the appropriate options](https://dev.mysql.com/doc/refman/8.1/en/change-replication-source-to.html) command, use the binary log filename and position shown in the `xtrabackup_binlog_info` file to start replication.
 
-If you are using 8.0.23 or later, use the [CHANGE_REPLICATION_SOURCE_TO and the appropriate options](https://dev.mysql.com/doc/refman/8.0/en/change-replication-source-to.html). `CHANGE_MASTER_TO` is deprecated.
-
-A more detailed procedure is found in  How to setup a replica for replication in 6 simple steps with Percona XtraBackup.
+A more detailed procedure is found in  [How to setup a replica for replication in 6 simple steps with Percona XtraBackup](set-up-replication.md).

--- a/docs/xbstream-binary-overview.md
+++ b/docs/xbstream-binary-overview.md
@@ -14,8 +14,8 @@ This utility has a tar-like interface:
 
 * with the `-x` option it extracts files from the stream read from its
 standard input to the current directory unless specified otherwise with the
-`-c` option. Support for parallel extraction with the `--parallel`
-option has been implemented in *Percona XtraBackup* 2.4.7.
+`-c` option. The parallel extraction is supported with the `--parallel`
+option.
 
 * with the `-c` option it streams files specified on the command line to its
 standard output.
@@ -24,22 +24,18 @@ standard output.
 decrypt encrypted files when extracting input stream. Supported values for
 this option are: `AES128`, `AES192`, and `AES256`. Either
 `--encrypt-key` or `--encrypt-key-file` options must be specified to
-provide encryption key, but not both. This option has been implemented in
-*Percona XtraBackup* 2.4.7.
+provide encryption key, but not both.
 
 * with the `--encrypt-threads` option you can specify the number of threads
-for parallel data encryption. The default value is `1`. This option has
-been implemented in *Percona XtraBackup* 2.4.7.
+for parallel data encryption. The default value is `1`.
 
 * the `--encrypt-key` option is used to specify the encryption key that will
 be used. It can’t be used with `--encrypt-key-file` option because they
-are mutually exclusive. This option has been implemented in *Percona
-XtraBackup* 2.4.7.
+are mutually exclusive. 
 
 * the `--encrypt-key-file` option is used to specify the file that contains
 the encryption key. It can’t be used with `--encrypt-key` option.
-because they are mutually exclusive. This option has been implemented in
-*Percona XtraBackup* 2.4.7.
+because they are mutually exclusive. 
 
 The utility also tries to minimize its impact on the OS page cache by using the
 appropriate `posix_fadvise()` calls when available.

--- a/docs/xtrabackup-files.md
+++ b/docs/xtrabackup-files.md
@@ -66,18 +66,18 @@ class="pre">xtrabackup_logfile</span></code
 ></td>
 <td>Contains data needed for running the: <code><span 
 class="pre">--prepare</span></code>.
->     The bigger this file is the <code><span 
+     The bigger this file is the <code><span 
 class="pre">--prepare</span></code> process
->     will take longer to finish.
+     will take longer to finish.
 </td></tr>
 <tr><td><code><span 
 class="pre">&lt;table_name&gt;.delta.meta</span></code
 ></td>
 <td><p>This file is going to be created when performing the incremental 
 backup.
->     It contains the per-table delta metadata: page size, size of compressed
->     page (if the value is 0 it means the tablespace isn’t compressed) and
->     space id. Example of this file:</p>
+     It contains the per-table delta metadata: page size, size of compressed
+     page (if the value is 0 it means the tablespace isn’t compressed) and
+     space id. Example of this file:</p>
 <div class="last highlight-text"><div class="highlight"><pre><span></span>page_size = 16384
 zip_size = 0
 space_id = 0

--- a/docs/xtrabackup-option-reference.md
+++ b/docs/xtrabackup-option-reference.md
@@ -374,7 +374,7 @@ If there are still such queries when the timeout expires, xtrabackup
 terminates with an error. Default is `0`, in which case it does not wait
 for queries to complete and starts `FLUSH TABLES WITH READ LOCK`
 immediately. Where supported xtrabackup will
-automatically use [Backup Locks](https://docs.percona.com/percona-server/8.0/backup-locks.html)
+automatically use [Backup Locks](https://docs.percona.com/percona-server/8.1/backup-locks.html)
 as a lightweight alternative to `FLUSH TABLES WITH READ LOCK` to copy
 non-InnoDB data to avoid blocking DML queries that modify InnoDB tables.
 
@@ -386,7 +386,7 @@ xtrabackup to detect long-running queries with a non-zero value of
 is not started until such long-running queries exist. This option has no
 effect if `--ftwrl-wait-timeout` is `0`. Default value
 is `60` seconds. Where supported xtrabackup will
-automatically use [Backup Locks](https://docs.percona.com/percona-server/8.0/backup-locks.html)
+automatically use [Backup Locks](https://docs.percona.com/percona-server/8.1/backup-locks.html)
 as a lightweight alternative to `FLUSH TABLES WITH READ LOCK` to copy
 non-InnoDB data to avoid blocking DML queries that modify InnoDB tables.
 
@@ -512,7 +512,7 @@ starting `FLUSH TABLES WITH READ LOCK` and killing those queries that block
 it. Default is 0 seconds, which means xtrabackup will not attempt to kill
 any queries. In order to use this option xtrabackup user should have the
 `PROCESS` and `SUPER` privileges. Where supported, xtrabackup
-automatically uses [Backup locks](https://docs.percona.com/percona-server/8.0/backup-locks.html)
+automatically uses [Backup locks](https://docs.percona.com/percona-server/8.1/backup-locks.html)
 as a lightweight alternative to `FLUSH TABLES WITH READ LOCK` to copy
 non-InnoDB data to avoid blocking DML queries that modify InnoDB tables.
 
@@ -591,7 +591,7 @@ about the binary log position of the backup. This option shouldn’t be used if
 there are any `DDL` statements being executed or if any updates are
 happening on non-InnoDB tables (this includes the system MyISAM tables in the
 mysql database), otherwise it could lead to an inconsistent backup. Where
-supported xtrabackup will automatically use [Backup locks](https://docs.percona.com/percona-server/8.0/backup-locks.html)
+supported xtrabackup will automatically use [Backup locks](https://docs.percona.com/percona-server/8.1/backup-locks.html)
 as a lightweight alternative to `FLUSH TABLES WITH READ LOCK` to copy
 non-InnoDB data to avoid blocking DML queries that modify InnoDB tables.  If
 you are considering to use this because your backups are failing to acquire
@@ -749,14 +749,11 @@ be started and stopped until there are no open temporary tables. The backup
 will fail if `Slave_open_temp_tables` does not become zero after
 `--safe-slave-backup-timeout` seconds. The replication SQL
 thread will be restarted when the backup finishes. This option is
-implemented in order to deal with [replicating temporary tables](https://dev.mysql.com/doc/refman/5.7/en/replication-features-temptables.html)
-and isn’t necessary with Row-Based-Replication.
+implemented in order to deal with [replicating temporary tables](https://dev.mysql.com/doc/refman/8.1/en/replication-features-temptables.html) and isn’t necessary with Row-Based-Replication.
 
 !!! note
 
-    Prior to Percona XtraBackup 8.0.22-15.0, using a safe-slave-backup stops the SQL replica thread after the InnoDB tables and before the non-InnoDB tables are backed up.
-
-    As of Percona XtraBackup 8.0.22-15.0, using a safe-slave-backup option stops the SQL replica thread before copying the InnoDB files.
+    Using a safe-slave-backup option stops the SQL replica thread before copying the InnoDB files.
 
 
 ### --safe-slave-backup-timeout(=SECONDS)


### PR DESCRIPTION
	modified:   docs/accelerate-backup-process.md
	modified:   docs/binaries-overview.md
	modified:   docs/create-gtid-replica.md
	modified:   docs/dictionary-cache.md
	modified:   docs/encrypted-innodb-tablespace-backups.md
	modified:   docs/faq.md
	modified:   docs/flush-tables-with-read-lock.md
	modified:   docs/glossary.md
	modified:   docs/how-xtrabackup-works.md
	modified:   docs/lock-options.md
	modified:   docs/privileges.md
	modified:   docs/quickstart-overview.md
	modified:   docs/restore-individual-partitions.md
	modified:   docs/set-up-replication.md
	modified:   docs/smart-memory-estimation.md
	modified:   docs/varify-backup.md
	modified:   docs/work-with-apparmor.md
	modified:   docs/work-with-selinux.md
	modified:   docs/working-with-binary-logs.md
	modified:   docs/xbstream-binary-overview.md
	modified:   docs/xtrabackup-files.md
	modified:   docs/xtrabackup-option-reference.md